### PR TITLE
Use a cross-platform image

### DIFF
--- a/lilypad_module.json.tmpl
+++ b/lilypad_module.json.tmpl
@@ -13,7 +13,7 @@
       "Docker": {
         "Entrypoint": [
           "/usr/local/bin/cowsay",
-          {{if .Message}}{{.Message}}{{else}}"Pass me an input called Message, like lilypad run cowsay:v0.0.2 -i Message=moo"{{end}}
+          {{if .Message}}{{.Message}}{{else}}"Pass me an input called Message, like lilypad run cowsay:<tag> -i Message=moo"{{end}}
         ],
         "Image": "richbrem/cowsay:latest"
       },

--- a/lilypad_module.json.tmpl
+++ b/lilypad_module.json.tmpl
@@ -12,10 +12,10 @@
       },
       "Docker": {
         "Entrypoint": [
-          "/usr/games/cowsay",
+          "/usr/local/bin/cowsay",
           {{if .Message}}{{.Message}}{{else}}"Pass me an input called Message, like lilypad run cowsay:v0.0.2 -i Message=moo"{{end}}
         ],
-        "Image": "grycap/cowsay@sha256:fad516b39e3a587f33ce3dbbb1e646073ef35e0b696bcf9afb1a3e399ce2ab0b"
+        "Image": "richbrem/cowsay:latest"
       },
       "Engine": "Docker",
       "Network": {


### PR DESCRIPTION
Use an image that is built cross-platform for both amd64 and arm64.
The Dockerfile for richbrem/cosway is in the repo lilypad-cosway.